### PR TITLE
Stacks Missing From Output

### DIFF
--- a/src/consolidator.ts
+++ b/src/consolidator.ts
@@ -42,7 +42,8 @@ export class Consolidator {
   commonQueryParams() {
     return {
       owner: this.context.payload.organization.login,
-      repo: `${this.context.payload.repository?.name}`
+      repo: `${this.context.payload.repository?.name}`,
+      per_page: 100
     };
   }
 


### PR DESCRIPTION
## What

The current queries to the GitHub API limit the returned results to 30 records by default. This requires pagination, or increasing the limit to the maximum of 100 records per page.

## Why

When running this with workflows with jobs that generate 30+ artifacts, this job will only show a maximum of 30 results, with the possibility of random results appearing to be missing.

## How

Increase the `per_page` parameter for GitHub API requests to 100.

## Testing

A branch has been pushed to enable integration testing: `dist/SRE-2469-stacks-missing-from-output`

Update your job configuration to use this branch.
```yaml
- id: previous_jobs
  uses: snapsheet/get-artifacts-as-outputs@dist/SRE-2469-stacks-missing-from-output
  with:
    output_filename: outputs.json
```

Run a job that tries to consolidate more than 30 individual job records and confirm that this resolves the issue.